### PR TITLE
Add mobile sidebar nav

### DIFF
--- a/challenges.html
+++ b/challenges.html
@@ -410,6 +410,7 @@
 </head>
 <body>
   <header class="header">
+    <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
     <div class="header-inner">
       <a href="dashboard.html" class="logo">Magic</a>
       <nav class="nav">
@@ -600,5 +601,6 @@
   }
   document.addEventListener('DOMContentLoaded', setupSoonButtons);
   </script>
+  <script>document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});</script>
 </body>
 </html> 

--- a/dashboard.html
+++ b/dashboard.html
@@ -1118,6 +1118,7 @@
 </head>
 <body>
   <header class="header">
+    <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
     <div class="header-inner">
       <a href="dashboard.html" class="logo">Magic</a>
       <nav class="nav">
@@ -2761,5 +2762,6 @@ function setupSoonButtons() {
 }
 document.addEventListener('DOMContentLoaded', setupSoonButtons);
 </script>
+<script>document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});</script>
 </body>
 </html>

--- a/group-plans.html
+++ b/group-plans.html
@@ -578,6 +578,7 @@
 </head>
 <body>
   <header class="header">
+    <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
     <div class="header-inner">
       <a href="dashboard.html" class="logo">Magic</a>
       <nav class="nav">
@@ -913,5 +914,6 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 </script>
+<script>document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});</script>
 </body>
 </html> 

--- a/index.html
+++ b/index.html
@@ -460,6 +460,7 @@
 <body>
     <!-- Header -->
     <header class="header">
+        <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
         <nav class="nav-container">
             <a href="#" class="logo">Magic</a>
             <ul class="nav-links">
@@ -751,6 +752,9 @@
                 });
             });
         });
+    </script>
+    <script>
+    document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});
     </script>
 </body>
 </html> 

--- a/inventory.html
+++ b/inventory.html
@@ -774,6 +774,7 @@
 </head>
 <body>
   <header class="header">
+    <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
     <div class="header-inner">
       <a href="dashboard.html" class="logo">Magic</a>
       <nav class="nav">
@@ -1793,5 +1794,6 @@
       }
     ];
   </script>
+<script>document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});</script>
 </body>
 </html> 

--- a/market.html
+++ b/market.html
@@ -1069,6 +1069,7 @@
 </head>
 <body>
   <header class="header">
+    <button class="burger" id="burgerBtn"><span></span><span></span><span></span></button>
     <div class="header-inner">
       <a href="dashboard.html" class="logo">Magic</a>
       <nav class="nav">
@@ -1733,6 +1734,6 @@
       }
     });
   </script>
-
+<script>document.addEventListener("DOMContentLoaded",function(){const b=document.getElementById("burgerBtn"),h=document.querySelector(".header");if(b&&h){b.addEventListener("click",()=>{h.classList.toggle("nav-open")});}});</script>
 </body>
 </html> 

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -36,3 +36,46 @@
     flex-direction: column;
   }
 }
+
+/* Mobile sidebar navigation */
+.burger {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.burger span {
+  width: 24px;
+  height: 3px;
+  background: currentColor;
+}
+
+@media (max-width: 768px) {
+  .burger { display: flex; }
+  .header-inner,
+  .nav-container {
+    position: fixed;
+    top: 0;
+    left: -250px;
+    width: 250px;
+    height: 100%;
+    background: #fff;
+    flex-direction: column;
+    padding-top: 4rem;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.1);
+    transition: left 0.3s;
+    z-index: 1000;
+  }
+  .header.nav-open .header-inner,
+  .header.nav-open .nav-container { left: 0; }
+  .header-inner .nav,
+  .nav-links,
+  .auth-buttons,
+  .header-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add burger toggle that turns header into a sidebar on mobile
- style responsive navigation in `responsive.css`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6867e745ec888327aadf9e20a1805c3c